### PR TITLE
Update EntryLayout to get the value of entry.collection

### DIFF
--- a/src/layouts/EntryLayout.astro
+++ b/src/layouts/EntryLayout.astro
@@ -23,8 +23,8 @@ const publishDate = entry.data.publishedOn.toLocaleDateString("en-us", {
   day: "numeric",
 });
 
-const fullUrl = `https://tylerwray.me/blog/${entry.slug}/`;
-const githubEditPath = `/src/content/blog/${entry.slug}.md`;
+const fullUrl = `https://tylerwray.me/${entry.collection}/${entry.slug}/`;
+const githubEditPath = `/src/content/${entry.collection}/${entry.slug}.md`;
 
 const headings: MarkdownHeading[] = [
   { depth: 2, slug: "overview", text: "Overview" },


### PR DESCRIPTION
Currently all the links assume that the current article is a blog and will redirect you to a /blog, while it could be a /tutorials